### PR TITLE
INS-1515

### DIFF
--- a/Services/dataset.service.js
+++ b/Services/dataset.service.js
@@ -87,7 +87,7 @@ const search = async (searchText, filters, options) => {
       return acc;
     }, {});
     const highlight = Object.keys(DATASET_SEARCH_RETURN_MAPPING).reduce((acc, key) => {
-      if (!ds.highlight || !ds.highlight.hasOwnProperty(key)) {
+      if (!ds.highlight || !ds.highlight.hasOwnProperty(`${key}.search`)) {
         return acc;
       }
 

--- a/Services/dataset.service.js
+++ b/Services/dataset.service.js
@@ -79,10 +79,18 @@ const search = async (searchText, filters, options) => {
 
     // Rename return fields and highlights according to mappings
     const content = Object.keys(DATASET_SEARCH_RETURN_MAPPING).reduce((acc, key) => {
+      if (!ds._source || !ds._source.hasOwnProperty(key)) {
+        return acc;
+      }
+
       acc[DATASET_SEARCH_RETURN_MAPPING[key]] = ds._source[key];
       return acc;
     }, {});
     const highlight = Object.keys(DATASET_SEARCH_RETURN_MAPPING).reduce((acc, key) => {
+      if (!ds.highlight || !ds.highlight.hasOwnProperty(key)) {
+        return acc;
+      }
+
       acc[DATASET_SEARCH_RETURN_MAPPING[key]] = ds.highlight[`${key}.search`];
       return acc;
     }, {});


### PR DESCRIPTION
### Overview

Fix crash

### Change Details (Specifics)

Crash happened if no source or highlight object came back from Opensearch. This PR makes sure the backend catches that.

### Related Ticket(s)

https://tracker.nci.nih.gov/browse/INS-1515
