### PR TITLE
INS-1576 and INS-1582

### DIFF
--- a/Services/dataset.service.js
+++ b/Services/dataset.service.js
@@ -95,13 +95,13 @@ const search = async (searchText, filters, options) => {
       return acc;
     }, {});
 
+    // Isolate dataset_uuid from the rest of the content
+    const { dataset_uuid, ...contentWithoutUuid } = content;
+
     if (!ds.inner_hits) {
       return {
-        dataset_uuid: content.dataset_uuid,
-        content: (() => {
-          const { dataset_uuid, ...contentWithoutUuid } = content;
-          return contentWithoutUuid;
-        })(),
+        dataset_uuid,
+        content: contentWithoutUuid,
         highlight: highlight
       };
     }
@@ -130,11 +130,8 @@ const search = async (searchText, filters, options) => {
     }
 
     return {
-      dataset_uuid: content.dataset_uuid,
-      content: (() => {
-        const { dataset_uuid, ...contentWithoutUuid } = content;
-        return contentWithoutUuid;
-      })(),
+      dataset_uuid,
+      content: contentWithoutUuid,
       highlight: highlight,
       additionalHits: additionalHits
     };

--- a/Services/dataset.service.js
+++ b/Services/dataset.service.js
@@ -96,7 +96,14 @@ const search = async (searchText, filters, options) => {
     }, {});
 
     if (!ds.inner_hits) {
-      return {content: content, highlight: highlight};
+      return {
+        dataset_uuid: content.dataset_uuid,
+        content: (() => {
+          const { dataset_uuid, ...contentWithoutUuid } = content;
+          return contentWithoutUuid;
+        })(),
+        highlight: highlight
+      };
     }
 
     const terms = Object.keys(ds.inner_hits);
@@ -121,7 +128,16 @@ const search = async (searchText, filters, options) => {
       tmp.highlight['additional.attr_set.k'] = utils.consolidateHighlight(additionalHitsDict[key].highlight);
       additionalHits.push(tmp);
     }
-    return {content: content, highlight: highlight, additionalHits: additionalHits};
+
+    return {
+      dataset_uuid: content.dataset_uuid,
+      content: (() => {
+        const { dataset_uuid, ...contentWithoutUuid } = content;
+        return contentWithoutUuid;
+      })(),
+      highlight: highlight,
+      additionalHits: additionalHits
+    };
   });
   result.total = searchResults.hits.total.value;
   result.data = datasets;

--- a/Utils/datasetFields.js
+++ b/Utils/datasetFields.js
@@ -42,7 +42,7 @@ const DATASET_HIGHLIGHT_FIELDS = DATASET_SEARCH_FIELDS;
 
 // Fields to return in dataset search results
 const DATASET_RETURN_FIELDS = [
-  // 'dataset_uuid',
+  'dataset_uuid',
   'dataset_source_repo',
   'dataset_title',
   'description',


### PR DESCRIPTION
### Overview

Dataset UUID returned in search results and export

### Change Details (Specifics)

Search results return `dataset_uuid` so that the frontend can create links to dataset details pages. Fixed issue where `dataset_uuid` was not being returned for the dataset search export.

### Related Ticket(s)

https://tracker.nci.nih.gov/browse/INS-1576
https://tracker.nci.nih.gov/browse/INS-1582
